### PR TITLE
Stop logging empty props of http request along with username

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 jobs:
   build:
-    working_directory: /go/src/github.com/Financial-Times/http-handlers-go
+    working_directory: /go/src/github.com/Financial-Times/http-handlers-go/httphandlers
     docker:
       - image: golang:1
         environment:
@@ -9,7 +9,8 @@ jobs:
           CIRCLE_TEST_REPORTS: /tmp/test-results
           CIRCLE_COVERAGE_REPORT: /tmp/coverage-results
     steps:
-      - checkout
+      - checkout:
+          path: /go/src/github.com/Financial-Times/http-handlers-go
       - run:
           name: External Dependencies
           command: |

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Financial-Times/http-handlers-go/v2
 go 1.13
 
 require (
-	github.com/Financial-Times/go-logger/v2 v2.0.0
+	github.com/Financial-Times/go-logger/v2 v2.0.1
 	github.com/Financial-Times/transactionid-utils-go v0.2.0
 	github.com/davecgh/go-spew v1.1.1-0.20170711183451-adab96458c51 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20161128210544-1f30fe9094a5

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Financial-Times/go-logger/v2 v2.0.0 h1:amSYqq+6KmOS5E0mg4BtnO+6zLQK9OSWAALxXaaf8wA=
-github.com/Financial-Times/go-logger/v2 v2.0.0/go.mod h1:Jpky5JYSX7xjGUClfA9hEMDmn40tUbfQQITjVIFGQiM=
+github.com/Financial-Times/go-logger/v2 v2.0.1 h1:iekEfSsUtlkg+YkXTZo+/fIN2VbZ2/3Hl9yolP3z5X8=
+github.com/Financial-Times/go-logger/v2 v2.0.1/go.mod h1:Jpky5JYSX7xjGUClfA9hEMDmn40tUbfQQITjVIFGQiM=
 github.com/Financial-Times/transactionid-utils-go v0.2.0 h1:YcET5Hd1fUGWWpQSVszYUlAc15ca8tmjRetUuQKRqEQ=
 github.com/Financial-Times/transactionid-utils-go v0.2.0/go.mod h1:tPAcAFs/dR6Q7hBDGNyUyixHRvg/n9NW/JTq8C58oZ0=
 github.com/davecgh/go-spew v0.0.0-20170829195320-a47672248388/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/httphandlers/http_handlers.go
+++ b/httphandlers/http_handlers.go
@@ -145,7 +145,7 @@ type hijackCloseNotifier struct {
 // trnasactionID is a unique id for this request.
 // status and size are used to provide the response HTTP status and size.
 func writeRequestLog(logger *logger.UPPLogger, req *http.Request, transactionID string, url url.URL, responseTime time.Duration, status, size int) {
-	username := "-"
+	username := ""
 	if url.User != nil {
 		if name := url.User.Username(); name != "" {
 			username = name

--- a/main.go
+++ b/main.go
@@ -1,5 +1,0 @@
-package main
-
-func main() {
-
-}


### PR DESCRIPTION
Stop logging - as username when username can't be found in the url.
Update go-logger so we don't log fields with empty values.