### PR TITLE
Extend http headers functionality 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,48 +1,13 @@
-version: 2
-jobs:
-  build:
-    working_directory: /go/src/github.com/Financial-Times/http-handlers-go/httphandlers
-    docker:
-      - image: golang:1
-        environment:
-          GOPATH: /go
-          CIRCLE_TEST_REPORTS: /tmp/test-results
-          CIRCLE_COVERAGE_REPORT: /tmp/coverage-results
-    steps:
-      - checkout:
-          path: /go/src/github.com/Financial-Times/http-handlers-go
-      - run:
-          name: External Dependencies
-          command: |
-            GO111MODULE=off go get github.com/mattn/goveralls
-            GO111MODULE=off go get -u github.com/jstemmer/go-junit-report
-            GO111MODULE=off go get -u github.com/haya14busa/goverage
-            curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.18.0
-            git clone git@github.com:Financial-Times/upp-coding-standard.git
-      - run:
-          name: Test Results
-          command: |
-            mkdir -p ${CIRCLE_TEST_REPORTS}
-            mkdir -p ${CIRCLE_COVERAGE_REPORT}
-      - run:
-          name: Go Build
-          command: go build -mod=readonly -v
-      - run:
-          name: Run linters
-          command: |
-            golangci-lint run --config upp-coding-standard/golangci-config/.golangci.yml --new-from-rev=$(git rev-parse origin/master)
-      - run:
-          name: Run Tests
-          command: |
-            go test -mod=readonly -race -v ./... | /go/bin/go-junit-report > ${CIRCLE_TEST_REPORTS}/main.xml
-            goverage -covermode=atomic -race -coverprofile=${CIRCLE_COVERAGE_REPORT}/coverage.out ./...
-      - run:
-          name: Upload Coverage
-          command: /go/bin/goveralls -coverprofile=${CIRCLE_COVERAGE_REPORT}/coverage.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
-      - store_test_results:
-          path: /tmp/test-results
+version: 2.1
+orbs:
+  ft-golang-ci: financial-times/golang-ci@1
 workflows:
-  version: 2
-  test-and-lint:
+  test-and-build-docker:
     jobs:
-      - build
+      - ft-golang-ci/build-and-test:
+          name: build-and-test-project
+  snyk-scanning:
+    jobs:
+      - ft-golang-ci/scan:
+          name: scan-dependencies
+          context: cm-team-snyk

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -1,0 +1,42 @@
+package httpclient
+
+import (
+	"fmt"
+	"net/http"
+
+	transactionidutils "github.com/Financial-Times/transactionid-utils-go"
+)
+
+type httpClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type ServiceClient struct {
+	Client      httpClient
+	ServiceCode string
+	Version     string
+	Runbook     string
+}
+
+func (c *ServiceClient) Do(req *http.Request) (*http.Response, error) {
+	headers := req.Header.Values("User-Agent")
+	// don't override "User-Agent" if it's already set
+	if len(headers) == 0 {
+		agent := fmt.Sprintf("%s/%s", c.ServiceCode, c.Version)
+		if c.Runbook != "" {
+			agent = fmt.Sprintf("%s/%s (+%s)", c.ServiceCode, c.Version, c.Runbook)
+		}
+		req.Header.Set("User-Agent", agent)
+	}
+
+	headers = req.Header.Values(transactionidutils.TransactionIDHeader)
+	// don't override "X-Request-Id" if it's already set
+	if len(headers) == 0 {
+		tid, err := transactionidutils.GetTransactionIDFromContext(req.Context())
+		if err == nil {
+			// add "X-Request-Id" header only if we have have tid in the context
+			req.Header.Set(transactionidutils.TransactionIDHeader, tid)
+		}
+	}
+	return c.Client.Do(req)
+}

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -1,0 +1,115 @@
+package httpclient
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	transactionidutils "github.com/Financial-Times/transactionid-utils-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClient(t *testing.T) {
+
+	tests := map[string]struct {
+		SetAgent   bool
+		Agent      string
+		ContextTID string
+		RequestTID string
+		Service    string
+		Version    string
+		Runbook    string
+		Expected   map[string]string
+	}{
+		"No agent set": {
+			SetAgent: false,
+			Service:  "service",
+			Version:  "v1.0",
+			Runbook:  "runbook.com",
+			Expected: map[string]string{"User-Agent": "service/v1.0 (+runbook.com)"},
+		},
+		"Agent empty set": {
+			SetAgent: true,
+			Agent:    "",
+			Service:  "service",
+			Version:  "v1.0",
+			Runbook:  "runbook.com",
+			Expected: map[string]string{"User-Agent": ""},
+		},
+		"Agent set": {
+			SetAgent: true,
+			Agent:    "test-agent",
+			Service:  "service",
+			Version:  "v1.0",
+			Runbook:  "runbook.com",
+			Expected: map[string]string{"User-Agent": "test-agent"},
+		},
+		"Agent with no runbook": {
+			Service:  "service",
+			Version:  "v1.0",
+			Expected: map[string]string{"User-Agent": "service/v1.0"},
+		},
+		"Context with transaction ID": {
+			ContextTID: "tid_test",
+			Service:    "service",
+			Version:    "v1.0",
+			Expected: map[string]string{
+				"User-Agent":   "service/v1.0",
+				"X-Request-Id": "tid_test",
+			},
+		},
+		"Request with transaction ID": {
+			ContextTID: "tid_test",
+			RequestTID: "tid_request",
+			Service:    "service",
+			Version:    "v1.0",
+			Expected: map[string]string{
+				"User-Agent":   "service/v1.0",
+				"X-Request-Id": "tid_request",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest("GET", "http://test.test", nil)
+
+			if test.SetAgent {
+				req.Header.Set("User-Agent", test.Agent)
+			}
+			if test.RequestTID != "" {
+				req.Header.Set(transactionidutils.TransactionIDHeader, test.RequestTID)
+			}
+			if test.ContextTID != "" {
+				req = req.WithContext(transactionidutils.TransactionAwareContext(req.Context(), test.ContextTID))
+			}
+
+			m := &mockClient{DoFunc: func(req *http.Request) (*http.Response, error) {
+				headers := req.Header
+				for key, val := range test.Expected {
+					assert.Equal(t, val, headers.Get(key))
+				}
+				return nil, nil
+			}}
+
+			client := ServiceClient{
+				Client:      m,
+				ServiceCode: test.Service,
+				Version:     test.Version,
+				Runbook:     test.Runbook,
+			}
+			_, _ = client.Do(req) // nolint: bodyclose
+		})
+	}
+}
+
+type mockClient struct {
+	DoFunc func(req *http.Request) (*http.Response, error)
+}
+
+func (m *mockClient) Do(req *http.Request) (*http.Response, error) {
+	return m.DoFunc(req)
+}

--- a/httphandlers/http_handlers.go
+++ b/httphandlers/http_handlers.go
@@ -42,6 +42,7 @@ type transactionAwareRequestLoggingHandler struct {
 
 func (h transactionAwareRequestLoggingHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	transactionID := transactionidutils.GetTransactionIDFromRequest(req)
+	req = req.WithContext(transactionidutils.TransactionAwareContext(req.Context(), transactionID))
 	w.Header().Set(transactionidutils.TransactionIDHeader, transactionID)
 	t := time.Now()
 	loggingResponseWriter := wrapWriter(w)


### PR DESCRIPTION
Proposal for extension to the library 
- Start writing transaction Id in the request context for the incoming requests.
- If transaction id is present in the outgoing request context, add it to the request headers
- Add service specific User-Agent header if non was set in the outgoing request. 
